### PR TITLE
[FOUNDATION] Adicionando suporte a deploy de schedulers

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,10 +53,15 @@ function wait() {
     pip install requests==2.25.1 && python $WAIT_PATH/wait.py $IMAGE $URL $TIMEOUT
 }
 
-# Check if cops API URL is on format: <domain>/v1/apps/<uuid-namespace>
-if [[ ${URL//-/} =~ /v1/apps/[[:xdigit:]]{32} ]];
-  then _log info "COPS API URL [${URL}] is valid with expected format [https?://<domain>/v1/apps/<uuid-namespace>]"
-  else _log erro "COPS API URL [${URL}] is NOT valid with expected format [https?://<domain>/v1/apps/<uuid-namespace>]" && exit 1
+
+# Check if cops API URL is on format: <domain>/v1/apps/<uuid> or <domain>/v1/schedulers/<uuid>/deploy
+uuid_pattern="[[:xdigit:]]{32}"
+if [[ ${URL//-/} =~ \/v1\/apps\/$uuid_pattern$ ]]; then 
+    _log info "COPS API URL [${URL}] is valid with expected format [http?://<domain>/v1/apps/<uuid>]"
+elif [[ ${URL//-/} =~ \/v1\/schedulers\/$uuid_pattern\/deploy$ ]]; then
+    _log erro "COPS API URL [${URL}] is valid with expected format [http?://<domain>/v1/schedulers/<uuid>/deploy]"
+else
+    _log erro "COPS API URL [${URL}] is NOT valid with expected format [http?://<domain>/v1/apps/<uuid>] or [http?://<domain>/v1/schedulers/<uuid>/deploy]" && exit 1
 fi
 
 # Check timeout before start
@@ -87,5 +92,3 @@ else
 fi
 
 deploy && wait
-
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,11 +57,11 @@ function wait() {
 # Check if cops API URL is on format: <domain>/v1/apps/<uuid> or <domain>/v1/schedulers/<uuid>/deploy
 uuid_pattern="[[:xdigit:]]{32}"
 if [[ ${URL//-/} =~ \/v1\/apps\/$uuid_pattern$ ]]; then 
-    _log info "COPS API URL [${URL}] is valid with expected format [http?://<domain>/v1/apps/<uuid>]"
+    _log info "COPS API URL [${URL}] is valid with expected format [https?://<domain>/v1/apps/<uuid>]"
 elif [[ ${URL//-/} =~ \/v1\/schedulers\/$uuid_pattern\/deploy$ ]]; then
-    _log info "COPS API URL [${URL}] is valid with expected format [http?://<domain>/v1/schedulers/<uuid>/deploy]"
+    _log info "COPS API URL [${URL}] is valid with expected format [https?://<domain>/v1/schedulers/<uuid>/deploy]"
 else
-    _log erro "COPS API URL [${URL}] is NOT valid with expected format [http?://<domain>/v1/apps/<uuid>] or [http?://<domain>/v1/schedulers/<uuid>/deploy]" && exit 1
+    _log erro "COPS API URL [${URL}] is NOT valid with expected format [https?://<domain>/v1/apps/<uuid>] or [https?://<domain>/v1/schedulers/<uuid>/deploy]" && exit 1
 fi
 
 # Check timeout before start

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,7 +59,7 @@ uuid_pattern="[[:xdigit:]]{32}"
 if [[ ${URL//-/} =~ \/v1\/apps\/$uuid_pattern$ ]]; then 
     _log info "COPS API URL [${URL}] is valid with expected format [http?://<domain>/v1/apps/<uuid>]"
 elif [[ ${URL//-/} =~ \/v1\/schedulers\/$uuid_pattern\/deploy$ ]]; then
-    _log erro "COPS API URL [${URL}] is valid with expected format [http?://<domain>/v1/schedulers/<uuid>/deploy]"
+    _log info "COPS API URL [${URL}] is valid with expected format [http?://<domain>/v1/schedulers/<uuid>/deploy]"
 else
     _log erro "COPS API URL [${URL}] is NOT valid with expected format [http?://<domain>/v1/apps/<uuid>] or [http?://<domain>/v1/schedulers/<uuid>/deploy]" && exit 1
 fi


### PR DESCRIPTION
# Descrição
Implementamos um novo tipo de app no COPS, chamado `schedulers`. 
Essa nova lógica usa endpoints separados das outras apps, então é preciso adequar a action para suportar esse novo endpoint.

# Solução
- Adicionei uma nova condição para validar a URL nova