### PR TITLE
Chore: Update setup-python

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - run: ${{ github.action_path }}/entrypoint.sh


### PR DESCRIPTION
Update action setup-python to [v5](https://github.com/actions/setup-python/releases/tag/v5.0.0)
<details><summary>details</summary>

### What's Changed

In scope of this release, we update node version runtime from node16 to node20 (https://github.com/actions/setup-python/pull/772). Besides, we update dependencies to the latest versions.

Full Changelog: https://github.com/actions/setup-python/compare/v4.8.0...v5.0.0

</details>